### PR TITLE
Ensure AmazonLinux v1 for AWS Lambda compatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:1
 
 MAINTAINER Alexis N-o "alexis@henaut.net"
 


### PR DESCRIPTION
This image is built upon amazonlinux:latest which is now Amazon Linux v2 (as of 28th of August 2018) but AWS Lambda is still running Amazon Linux v1