### PR TITLE
Update runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,17 @@ FROM amazonlinux:1
 MAINTAINER Alexis N-o "alexis@henaut.net"
 
 ENV DEFAULT_USER=myrmex
-ENV NODE_VERSION_4 4.3.2
-ENV NODE_VERSION_6 6.10.2
+ENV NODE_VERSION_6 6.10.3
 ENV NODE_VERSION_8 8.10.0
+ENV PYTHON_VERSION_3_6 3.6.8
+ENV PYTHON_VERSION_3_7 3.7.3
 
 # Install gcc add utilities to manage users and permissions
 RUN yum install -y gcc-c++ util-linux shadow-utils zlib-devel openssl-devel libffi-devel
 
-# Install node v4 node v6 and node v8 as commands "node4" "node6" and "node8"
+# Install node v6 and node v8 as commands "node6" and "node8"
 # Command "node" defaults to v8
-# Update npm to version 4
 RUN cd /opt &&\
-    curl -O https://nodejs.org/dist/v${NODE_VERSION_4}/node-v${NODE_VERSION_4}-linux-x64.tar.gz &&\
-    tar xvzf node-v${NODE_VERSION_4}-linux-x64.tar.gz &&\
-    ln -s /opt/node-v${NODE_VERSION_4}-linux-x64/bin/node /usr/local/bin/node4 &&\
-    ln -s /opt/node-v${NODE_VERSION_4}-linux-x64/bin/node /usr/local/bin/node &&\
-    ln -s /opt/node-v${NODE_VERSION_4}-linux-x64/bin/npm /usr/local/bin/npm &&\
-    /opt/node-v${NODE_VERSION_4}-linux-x64/bin/npm install -g npm@4 &&\
-    rm /usr/local/bin/node /usr/local/bin/npm &&\
     curl -O https://nodejs.org/dist/v${NODE_VERSION_6}/node-v${NODE_VERSION_6}-linux-x64.tar.gz &&\
     tar xvzf node-v${NODE_VERSION_6}-linux-x64.tar.gz &&\
     ln -s /opt/node-v${NODE_VERSION_6}-linux-x64/bin/node /usr/local/bin/node6 &&\
@@ -35,17 +28,28 @@ RUN cd /opt &&\
     ln -s /opt/node-v${NODE_VERSION_8}-linux-x64/bin/npm /usr/local/bin/npm &&\
     /opt/node-v${NODE_VERSION_8}-linux-x64/bin/npm install -g npm@4
 
-# Install python 3.6 and pip, python 2.7 is already available
+# Install python 3.6 and python 3.7 including pip, python 2.7 is already available
+# Command "python3" defaults to 3.7
 RUN curl -O https://bootstrap.pypa.io/get-pip.py &&\
     python get-pip.py &&\
-    curl -O https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tgz &&\
-    tar zxvf Python-3.6.1.tgz &&\
-    cd Python-3.6.1 &&\
-    ./configure --prefix=/opt/python3 &&\
+    curl -O https://www.python.org/ftp/python/${PYTHON_VERSION_3_6}/Python-${PYTHON_VERSION_3_6}.tgz &&\
+    tar zxvf Python-${PYTHON_VERSION_3_6}.tgz &&\
+    cd Python-${PYTHON_VERSION_3_6} &&\
+    ./configure --prefix=/opt/python-${PYTHON_VERSION_3_6} &&\
     make &&\
     make install &&\
-    ln -s /opt/python3/bin/python3 /usr/bin/python3 &&\
-    ln -s /opt/python3/bin/pip3 /usr/bin/pip3
+    ln -s /opt/python-${PYTHON_VERSION_3_6}/bin/python3 /usr/bin/python3.6 &&\
+    ln -s /opt/python-${PYTHON_VERSION_3_6}/bin/pip3 /usr/bin/pip3.6 && \
+    curl -O https://www.python.org/ftp/python/${PYTHON_VERSION_3_7}/Python-${PYTHON_VERSION_3_7}.tgz &&\
+    tar zxvf Python-${PYTHON_VERSION_3_7}.tgz &&\
+    cd Python-${PYTHON_VERSION_3_7} &&\
+    ./configure --prefix=/opt/python-${PYTHON_VERSION_3_7} &&\
+    make &&\
+    make install &&\
+    ln -s /opt/python-${PYTHON_VERSION_3_7}/bin/python3 /usr/bin/python3.7 &&\
+    ln -s /opt/python-${PYTHON_VERSION_3_7}/bin/pip3 /usr/bin/pip3.7 &&\
+    ln -s /opt/python-${PYTHON_VERSION_3_7}/bin/python3 /usr/bin/python3 &&\
+    ln -s /opt/python-${PYTHON_VERSION_3_7}/bin/pip3 /usr/bin/pip3
 
 
 # Add a script to modify the UID / GID for the default user if needed

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 ## Why?
 
 Some node and python modules require a build system because they contain c++ binding. Once deployed, the compiled
-module may not be complatible with the Amazon Lambda execution environment.
+module may not be compatible with the Amazon Lambda execution environment.
 
 A common solution to this problem is to build the package on an EC2 instance using an Amazon Linux AMI and then to
 deploy it in Amazon Lambda. Building serverless applications, it is ironic to be obliged to use an EC2 server to deploy code.
 
-This docker image is based on the [Amazon Linux](https://hub.docker.com/_/amazonlinux/) image and contains `gcc`,
-`python 2.7`, `python 3.6`, `pip`, `node 4.3`, `node 6.10` and `npm 4` to create packages for Amazon Lambda.
+This docker image is based on the [Amazon Linux 1](https://hub.docker.com/_/amazonlinux/) image and contains `gcc`,
+`python 2.7`, `python 3.6`, `python 3.7`, `pip`, `node 6.10`, `node 8.10` to create packages for Amazon Lambda.
 
 Using the docker image `myrmex/lambda-packager`, you can avoid errors like these during execution in Amazon Lambda:
 
@@ -51,20 +51,29 @@ docker run -e HOST_UID=`id -u` -e HOST_GID=`id -g` -v `pwd`:/data myrmex/lambda-
 
 The `RUNTIME` environment variable allows to choose the runtime.
 
+
+#### Node 8.10
+
+Node 8.10 is the default runtime and does not require any special configuration.
+
 #### Node 6.10
 
-Node 6.10 is the default runtime and does not require any special configuration.
+```bash
+docker run -e RUNTIME=node6 -v `pwd`:/data myrmex/lambda-packager
+```
 
-#### Node 4.3
+#### Python 3.7
+
+Python 3.7 is the default Python 3 runtime and accepts the values `python3` or `python3.7`
 
 ```bash
-docker run -e RUNTIME=node4 -v `pwd`:/data myrmex/lambda-packager
+docker run -e RUNTIME=python3.7 -v `pwd`:/data myrmex/lambda-packager
 ```
 
 #### Python 3.6
 
 ```bash
-docker run -e RUNTIME=python3 -v `pwd`:/data myrmex/lambda-packager
+docker run -e RUNTIME=python3.6 -v `pwd`:/data myrmex/lambda-packager
 ```
 
 #### Python 2.7

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,18 +3,48 @@ set -e
 
 if [ `whoami` == "root" ]; then
 
-    if [ "$RUNTIME" == "node4" ]; then
-        echo "Setting node to v4"
-        rm /usr/local/bin/node /usr/local/bin/npm
-        ln -s /opt/node-v${NODE_VERSION_4}-linux-x64/bin/node /usr/local/bin/node
-        ln -s /opt/node-v${NODE_VERSION_4}-linux-x64/bin/npm /usr/local/bin/npm
+    if [ "$RUNTIME" == "" ]; then
+        echo "Using default runtime node v8"
     fi
 
+    if [ "$RUNTIME" == "node" ]; then
+        echo "Using default node v8 runtime"
+    fi
+    
     if [ "$RUNTIME" == "node6" ]; then
-        echo "Setting node to v6"
+        echo "Setting node runtime to v6"
         rm /usr/local/bin/node /usr/local/bin/npm
-        ln -s /opt/node-v${NODE_VERSION_6}-linux-x64/bin/node /usr/local/bin/node
-        ln -s /opt/node-v${NODE_VERSION_6}-linux-x64/bin/npm /usr/local/bin/npm
+        ln -sf /opt/node-v${NODE_VERSION_6}-linux-x64/bin/node /usr/local/bin/node
+        ln -sf /opt/node-v${NODE_VERSION_6}-linux-x64/bin/npm /usr/local/bin/npm
+    fi
+
+    if [ "$RUNTIME" == "node8" ]; then
+        echo "Setting node runtime to v8"
+        rm /usr/local/bin/node /usr/local/bin/npm
+        ln -sf /opt/node-v${NODE_VERSION_8}-linux-x64/bin/node /usr/local/bin/node
+        ln -sf /opt/node-v${NODE_VERSION_8}-linux-x64/bin/npm /usr/local/bin/npm
+    fi
+
+    if [ "$RUNTIME" == "python" ]; then
+        echo "Using default python v2 runtime"
+        ln -sf /usr/bin/python2.7 /usr/bin/python2
+    fi
+
+    if [ "$RUNTIME" == "python2" ]; then
+        echo "Setting python runtime to 2"
+        ln -sf /usr/bin/python2.7 /usr/bin/python2
+    fi
+
+    if [ "$RUNTIME" == "python3.6" ]; then
+        echo "Setting python runtime to 3.6"
+        ln -sf /opt/python-${PYTHON_VERSION_3_6}/bin/python3 /usr/bin/python3
+        ln -sf f/opt/python-${PYTHON_VERSION_3_6}/bin/pip3 /usr/bin/pip3
+    fi
+
+    if [ "$RUNTIME" == "python3.7" ]; then
+        echo "Setting python runtime to 3.7"
+        ln -sf /opt/python-${PYTHON_VERSION_3_7}/bin/python3 /usr/bin/python3
+        ln -sf /opt/python-${PYTHON_VERSION_3_7}/bin/pip3 /usr/bin/pip3
     fi
 
     if [ "$HOST_UID" != "" ]; then


### PR DESCRIPTION
- Dropped support for node v4 as it was marked EOL on 2018-04-30
- Bumped minor version of node v6
- Bumped minor version of python v3.6
- Added python3.7 support
- Default python3 runtime is 3.7